### PR TITLE
Rename crate to comply with new naming rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 
-name = "conduit-mime-types"
+name = "conduit_mime_types"
 version = "0.7.3"
 authors = ["wycats@gmail.com"]
 license = "MIT"


### PR DESCRIPTION
Very quick change. Probably breaks stuff with respect to crates.io.