### PR TITLE
Use `criterion` for benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,10 @@ repository = "https://github.com/conduit-rust/mime-types"
 [dependencies]
 serde = "1.0"
 serde_json = "1.0"
+
+[dev-dependencies]
+criterion = { version = "0.3", features = ["html_reports"] }
+
+[[bench]]
+name = "load-data"
+harness = false

--- a/benches/load-data.rs
+++ b/benches/load-data.rs
@@ -1,0 +1,12 @@
+extern crate conduit_mime_types;
+extern crate criterion;
+
+use conduit_mime_types::Types;
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("Types::new()", |b| b.iter(|| Types::new()));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![warn(rust_2018_idioms)]
-#![cfg_attr(test, feature(test))]
 
 extern crate serde;
 extern crate serde_json;
@@ -54,14 +53,8 @@ impl Types {
 
 #[cfg(test)]
 mod test {
-    extern crate test;
     use std::path::Path;
     use Types;
-
-    #[bench]
-    fn bench_load_types(b: &mut test::Bencher) {
-        b.iter(|| Types::new());
-    }
 
     #[test]
     fn test_by_ext() {


### PR DESCRIPTION
Using `test::Bencher` requires the `nightly` compiler, which makes it hard to simply run `cargo test` with the stable compiler at the moment.