### PR TITLE
Update `edition` to `2018`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["wycats@gmail.com"]
 license = "MIT"
 description = "MIME type definitions for conduit"
 repository = "https://github.com/conduit-rust/mime-types"
+edition = "2018"
 
 [dependencies]
 serde = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,3 @@
-#![warn(rust_2018_idioms)]
-
-extern crate serde;
-extern crate serde_json;
-
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;
@@ -53,8 +48,8 @@ impl Types {
 
 #[cfg(test)]
 mod test {
+    use crate::Types;
     use std::path::Path;
-    use Types;
 
     #[test]
     fn test_by_ext() {


### PR DESCRIPTION
because 2021 is already around the corner 😅 

This should be considered a breaking change, as it raises the Minimum Supported Rust Version to v1.31